### PR TITLE
Migrating adID feature branch to current dev branch

### DIFF
--- a/AEPEdgeIdentity.xcodeproj/project.pbxproj
+++ b/AEPEdgeIdentity.xcodeproj/project.pbxproj
@@ -25,7 +25,6 @@
 		43E2977FF5B6CE67BFA18068 /* Pods_FunctionalTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AF5FC2982E587DB999C37858 /* Pods_FunctionalTests.framework */; };
 		4C4B7D8C27A0CA2F00C0CE25 /* IdentityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C4B7D8B27A0CA2F00C0CE25 /* IdentityTests.swift */; };
 		4C4B7D8E27A0CAC900C0CE25 /* Event+Identity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C4B7D8D27A0CAC900C0CE25 /* Event+Identity.swift */; };
-		4C4B7D8F27A0CAC900C0CE25 /* Event+Identity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C4B7D8D27A0CAC900C0CE25 /* Event+Identity.swift */; };
 		4C4B7D9027A0CAC900C0CE25 /* Event+Identity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C4B7D8D27A0CAC900C0CE25 /* Event+Identity.swift */; };
 		4C4B7D9127A1114600C0CE25 /* IdentityConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43BAB7125BBAFC700B08CC0 /* IdentityConstants.swift */; };
 		4C4B7D9227A111A500C0CE25 /* IdentityConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43BAB7125BBAFC700B08CC0 /* IdentityConstants.swift */; };
@@ -890,7 +889,6 @@
 				BFF6499B25C0ACC00012A4C5 /* IdentityPropertiesTests.swift in Sources */,
 				BFF6498F25C0AC0F0012A4C5 /* ECIDTests.swift in Sources */,
 				BFF649A125C0D29D0012A4C5 /* IdentityStateTests.swift in Sources */,
-				4C4B7D8F27A0CAC900C0CE25 /* Event+Identity.swift in Sources */,
 				BFF64AEB25C8A9B40012A4C5 /* MockExtension.swift in Sources */,
 				D43BAB2825BBA8A900B08CC0 /* IdentityTests.swift in Sources */,
 				BFF649B725C0FC810012A4C5 /* IdentityMapTests.swift in Sources */,

--- a/AEPEdgeIdentity.xcodeproj/project.pbxproj
+++ b/AEPEdgeIdentity.xcodeproj/project.pbxproj
@@ -775,7 +775,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    ./Pods/SwiftLint/swiftlint lint --config ${SRCROOT}/.swiftlint.yml Sources\nelse\n    echo \"warning: SwiftLint is not installed, please run the pod install command from the project root directory.\"\nfi\n";
+			shellScript = "if which ${PODS_ROOT}/SwiftLint/swiftlint >/dev/null; then\n    ${PODS_ROOT}/SwiftLint/swiftlint lint --config ${SRCROOT}/.swiftlint.yml Sources\nelse\n    echo \"warning: SwiftLint is not installed, please run the pod install command from the project root directory.\"\nfi\n";
 		};
 		D43BAC2125BF4A3A00B08CC0 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/AEPEdgeIdentity.xcodeproj/project.pbxproj
+++ b/AEPEdgeIdentity.xcodeproj/project.pbxproj
@@ -23,7 +23,7 @@
 /* Begin PBXBuildFile section */
 		004DF6198BD3329E598B8FAB /* Pods_TestApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6DE39896A5E0D0C2B397EDD3 /* Pods_TestApp.framework */; };
 		43E2977FF5B6CE67BFA18068 /* Pods_FunctionalTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AF5FC2982E587DB999C37858 /* Pods_FunctionalTests.framework */; };
-		4C4B7D8C27A0CA2F00C0CE25 /* IdentityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C4B7D8B27A0CA2F00C0CE25 /* IdentityTests.swift */; };
+		4C4B7D8C27A0CA2F00C0CE25 /* IdentityAdIDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C4B7D8B27A0CA2F00C0CE25 /* IdentityAdIDTests.swift */; };
 		4C4B7D8E27A0CAC900C0CE25 /* Event+Identity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C4B7D8D27A0CAC900C0CE25 /* Event+Identity.swift */; };
 		4C4B7D9027A0CAC900C0CE25 /* Event+Identity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C4B7D8D27A0CAC900C0CE25 /* Event+Identity.swift */; };
 		4C4B7D9127A1114600C0CE25 /* IdentityConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43BAB7125BBAFC700B08CC0 /* IdentityConstants.swift */; };
@@ -111,7 +111,7 @@
 		21194EEA9E974D4025B62CB7 /* Pods-FunctionalTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FunctionalTests.release.xcconfig"; path = "Target Support Files/Pods-FunctionalTests/Pods-FunctionalTests.release.xcconfig"; sourceTree = "<group>"; };
 		211C042081BAB03AF0C00D2D /* Pods_TestAppObjC.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TestAppObjC.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4ADECD91E29628B33C7D45F5 /* Pods-UnitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UnitTests.release.xcconfig"; path = "Target Support Files/Pods-UnitTests/Pods-UnitTests.release.xcconfig"; sourceTree = "<group>"; };
-		4C4B7D8B27A0CA2F00C0CE25 /* IdentityTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IdentityTests.swift; sourceTree = "<group>"; };
+		4C4B7D8B27A0CA2F00C0CE25 /* IdentityAdIDTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IdentityAdIDTests.swift; sourceTree = "<group>"; };
 		4C4B7D8D27A0CAC900C0CE25 /* Event+Identity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Event+Identity.swift"; sourceTree = "<group>"; };
 		4EC5B471416D7ABA4A62D49C /* Pods-AEPIdentityEdge.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AEPIdentityEdge.release.xcconfig"; path = "Target Support Files/Pods-AEPIdentityEdge/Pods-AEPIdentityEdge.release.xcconfig"; sourceTree = "<group>"; };
 		56FF745F8E6F9C0458C1ECA3 /* Pods-AEPIdentityEdgeSampleApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AEPIdentityEdgeSampleApp.debug.xcconfig"; path = "Target Support Files/Pods-AEPIdentityEdgeSampleApp/Pods-AEPIdentityEdgeSampleApp.debug.xcconfig"; sourceTree = "<group>"; };
@@ -358,7 +358,7 @@
 		D43BAB3725BBA8C700B08CC0 /* FunctionalTests */ = {
 			isa = PBXGroup;
 			children = (
-				4C4B7D8B27A0CA2F00C0CE25 /* IdentityTests.swift */,
+				4C4B7D8B27A0CA2F00C0CE25 /* IdentityAdIDTests.swift */,
 				BFF64A5A25C4C5410012A4C5 /* EdgeIdentity+IdentityDirectTests.swift */,
 				D43BAB3A25BBA8C700B08CC0 /* Info.plist */,
 				BFF64A6925C4C6A90012A4C5 /* TestHelpers.swift */,
@@ -902,7 +902,7 @@
 				4C4B7D9127A1114600C0CE25 /* IdentityConstants.swift in Sources */,
 				BFF64A6025C4C63F0012A4C5 /* EdgeIdentity+IdentityDirectTests.swift in Sources */,
 				4C4B7D9027A0CAC900C0CE25 /* Event+Identity.swift in Sources */,
-				4C4B7D8C27A0CA2F00C0CE25 /* IdentityTests.swift in Sources */,
+				4C4B7D8C27A0CA2F00C0CE25 /* IdentityAdIDTests.swift in Sources */,
 				BFF64AEE25C8A9B40012A4C5 /* MockDataStore.swift in Sources */,
 				BFF64AEA25C8A9B40012A4C5 /* TestableExtensionRuntime.swift in Sources */,
 				BFF64A6A25C4C6A90012A4C5 /* TestHelpers.swift in Sources */,

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,17 +2,17 @@ PODS:
   - AEPAssurance (3.0.0):
     - AEPCore (>= 3.1.0)
     - AEPServices (>= 3.1.0)
-  - AEPCore (3.4.0):
+  - AEPCore (3.4.2):
     - AEPRulesEngine (>= 1.1.0)
-    - AEPServices (>= 3.4.0)
-  - AEPIdentity (3.4.0):
-    - AEPCore (>= 3.4.0)
-  - AEPLifecycle (3.4.0):
-    - AEPCore (>= 3.4.0)
+    - AEPServices (>= 3.4.2)
+  - AEPIdentity (3.4.2):
+    - AEPCore (>= 3.4.2)
+  - AEPLifecycle (3.4.2):
+    - AEPCore (>= 3.4.2)
   - AEPRulesEngine (1.1.0)
-  - AEPServices (3.4.0)
-  - AEPSignal (3.4.0):
-    - AEPCore (>= 3.4.0)
+  - AEPServices (3.4.2)
+  - AEPSignal (3.4.2):
+    - AEPCore (>= 3.4.2)
   - SwiftLint (0.44.0)
 
 DEPENDENCIES:
@@ -37,12 +37,12 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   AEPAssurance: 18068627111e366a851dc2166239f22b665101bd
-  AEPCore: 8f0ce46f06cd2289b42fa2ff4b91dff7ace1b375
-  AEPIdentity: ca6f0f2830bf6fb14dfffb3fe0e30d1dfc3fe0b2
-  AEPLifecycle: 1115c8c7323ee78d9dff7c4d1667c69da55f7930
+  AEPCore: b01856bf24972e4720cb0511a358d1e68067252a
+  AEPIdentity: fbf755560afcbb0acd66cd5b6a1c147530fca5f6
+  AEPLifecycle: 1e0e843465fb143f8d8949dcf06de169d5c26f62
   AEPRulesEngine: bb2927ed5501ddf9754c66e97f8d2b1cf8e33b19
-  AEPServices: 27030d89e8c2ba5ea48f26fe05c94d73e519de27
-  AEPSignal: 378399354d202a7b835a9abe8d9ad63622c8c52f
+  AEPServices: 3214311f239c8cdc6267d757200b05ec0ab05878
+  AEPSignal: be3a4789b492f4d5a5aef7408f30ff8e866d1d79
   SwiftLint: e96c0a8c770c7ebbc4d36c55baf9096bb65c4584
 
 PODFILE CHECKSUM: 998b4a8b4d3c95683f7f6f806ef3f2928fc5d84d

--- a/SampleApps/TestApp/ContentView.swift
+++ b/SampleApps/TestApp/ContentView.swift
@@ -34,12 +34,12 @@ struct ContentView: View {
                         Text("Assurance")
                     }
                 )
-                
+
                 NavigationLink(
-                   destination: AdvertisingIdentifierView(),
-                   label: {
-                       Text("Set Advertising Identifier")
-                   })
+                    destination: AdvertisingIdentifierView(),
+                    label: {
+                        Text("Set Advertising Identifier")
+                    })
 
                 NavigationLink(
                     destination: CustomIdentifierView(),

--- a/Sources/Event+Identity.swift
+++ b/Sources/Event+Identity.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 Adobe. All rights reserved.
+// Copyright 2022 Adobe. All rights reserved.
 // This file is licensed to you under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License. You may obtain a copy
 // of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/Sources/Event+Identity.swift
+++ b/Sources/Event+Identity.swift
@@ -18,23 +18,18 @@ extension Event {
     /// Reads the advertising ID from the event data
     ///
     /// Performs a sanitization of values, converting `nil`, `""`, and `IdentityConstants.Default.ZERO_ADVERTISING_ID` into `""`
-    /// Provides a built-in check of first verifying that the Event is an AdId event using `isAdIdEvent`before attempting to access the value and perform sanitization
-    ///
+    /// Recommended to use `isAdIdEvent` check before using this value
     /// - Returns: the extracted AdId, or `nil` if the Event is not an AdId event,
-    var adId: String? {
-        if isAdIdEvent {
-            // Sanity check; Sanitize `nil` String value
-            guard let adId = data?[IdentityConstants.EventDataKeys.ADVERTISING_IDENTIFIER] as? String else {
-                return ""
-            }
-            // Sanitize all-zero ID value
-            if adId == IdentityConstants.Default.ZERO_ADVERTISING_ID {
-                return ""
-            }
-            return adId
-        } else {
-            return nil
+    public var adId: String? {
+        // Sanity check; Sanitize `nil` String value
+        guard let adId = data?[IdentityConstants.EventDataKeys.ADVERTISING_IDENTIFIER] as? String else {
+            return ""
         }
+        // Sanitize all-zero ID value
+        if adId == IdentityConstants.Default.ZERO_ADVERTISING_ID {
+            return ""
+        }
+        return adId
     }
     
     /// Checks if the Event is an AdId event, based on the presence of the `ADVERTISING_IDENTIFIER` key and corresponding `String` value type at the top level of `data`.
@@ -42,11 +37,6 @@ extension Event {
     /// Because the `Any` type anonymizes the original classes of nil values, all checks against optional types pass if the actual value is `nil`.
     /// Currently, only non-optional String values trigger updating the AdID as the value is compared to the non-optional `String` class
     var isAdIdEvent: Bool {
-        if data?.keys.contains(IdentityConstants.EventDataKeys.ADVERTISING_IDENTIFIER) ?? false {
-            if data?[IdentityConstants.EventDataKeys.ADVERTISING_IDENTIFIER] is String {
-                return true
-            }
-        }
-        return false
+        return data?.keys.contains(IdentityConstants.EventDataKeys.ADVERTISING_IDENTIFIER) ?? false && data?[IdentityConstants.EventDataKeys.ADVERTISING_IDENTIFIER] is String
     }
 }

--- a/Sources/Event+Identity.swift
+++ b/Sources/Event+Identity.swift
@@ -20,7 +20,7 @@ extension Event {
     /// Performs a sanitization of values, converting `nil`, `""`, and `IdentityConstants.Default.ZERO_ADVERTISING_ID` into `""`
     /// Recommended to use `isAdIdEvent` check before using this value
     /// - Returns: the extracted AdId, or `nil` if the Event is not an AdId event,
-    var adId: String? {
+    var adId: String {
         // Sanity check; Sanitize `nil` String value
         guard let adId = data?[IdentityConstants.EventDataKeys.ADVERTISING_IDENTIFIER] as? String else {
             return ""

--- a/Sources/Event+Identity.swift
+++ b/Sources/Event+Identity.swift
@@ -15,13 +15,35 @@ import Foundation
 
 extension Event {
 
-    /// Reads the advertising from the event data
+    /// Reads the advertising ID from the event data
+    ///
+    /// Performs a sanitization of values, converting `nil`, `""`, and `IdentityConstants.Default.ZERO_ADVERTISING_ID` into `""`
+    /// Provides a built-in check of first verifying that the Event is an AdId event using `isAdIdEvent`before attempting to access the value and perform sanitization
+    ///
+    /// - Returns: the extracted AdId, or `nil` if the Event is not an AdId event,
     var adId: String? {
-        let adId = data?[IdentityConstants.EventDataKeys.ADVERTISING_IDENTIFIER] as? String
-        if adId == IdentityConstants.Default.ZERO_ADVERTISING_ID {
-            return ""
+        if isAdIdEvent {
+            // Sanitize `nil` String value
+            guard let adId = data?[IdentityConstants.EventDataKeys.ADVERTISING_IDENTIFIER] as? String else {
+                return ""
+            }
+            // Sanitize all-zero ID value
+            if adId == IdentityConstants.Default.ZERO_ADVERTISING_ID {
+                return ""
+            }
+            return adId
+        } else {
+            return nil
         }
-
-        return adId
+    }
+    
+    /// Checks if the Event is an AdId event, based on the presence of the `ADVERTISING_IDENTIFIER` key and corresponding `String` value type at the top level of `data`.
+    var isAdIdEvent: Bool {
+        if data?.keys.contains(IdentityConstants.EventDataKeys.ADVERTISING_IDENTIFIER) ?? false {
+            if data?[IdentityConstants.EventDataKeys.ADVERTISING_IDENTIFIER] is String {
+                return true
+            }
+        }
+        return false
     }
 }

--- a/Sources/Event+Identity.swift
+++ b/Sources/Event+Identity.swift
@@ -20,7 +20,7 @@ extension Event {
     /// Performs a sanitization of values, converting `nil`, `""`, and `IdentityConstants.Default.ZERO_ADVERTISING_ID` into `""`
     /// Recommended to use `isAdIdEvent` check before using this value
     /// - Returns: the extracted AdId, or `nil` if the Event is not an AdId event,
-    public var adId: String? {
+    var adId: String? {
         // Sanity check; Sanitize `nil` String value
         guard let adId = data?[IdentityConstants.EventDataKeys.ADVERTISING_IDENTIFIER] as? String else {
             return ""

--- a/Sources/Event+Identity.swift
+++ b/Sources/Event+Identity.swift
@@ -23,7 +23,7 @@ extension Event {
     /// - Returns: the extracted AdId, or `nil` if the Event is not an AdId event,
     var adId: String? {
         if isAdIdEvent {
-            // Sanitize `nil` String value
+            // Sanity check; Sanitize `nil` String value
             guard let adId = data?[IdentityConstants.EventDataKeys.ADVERTISING_IDENTIFIER] as? String else {
                 return ""
             }
@@ -38,6 +38,9 @@ extension Event {
     }
     
     /// Checks if the Event is an AdId event, based on the presence of the `ADVERTISING_IDENTIFIER` key and corresponding `String` value type at the top level of `data`.
+    ///
+    /// Because the `Any` type anonymizes the original classes of nil values, all checks against optional types pass if the actual value is `nil`.
+    /// Currently, only non-optional String values trigger updating the AdID as the value is compared to the non-optional `String` class
     var isAdIdEvent: Bool {
         if data?.keys.contains(IdentityConstants.EventDataKeys.ADVERTISING_IDENTIFIER) ?? false {
             if data?[IdentityConstants.EventDataKeys.ADVERTISING_IDENTIFIER] is String {

--- a/Sources/Identity.swift
+++ b/Sources/Identity.swift
@@ -56,7 +56,7 @@ import Foundation
                                           createXDMSharedState: createXDMSharedState(data:event:),
                                           eventDispatcher: dispatch(event:))
     }
-    
+
     /// Handles events requesting for identifiers. Dispatches response event containing the identifiers. Called by listener registered with event hub.
     /// - Parameter event: the identity request event
     private func handleIdentityRequest(event: Event) {

--- a/Sources/Identity.swift
+++ b/Sources/Identity.swift
@@ -52,9 +52,11 @@ import Foundation
     /// Handles events to set the advertising identifier. Called by listener registered with event hub.
     /// - Parameter event: event containing `advertisingIdentifier` data
     private func handleRequestContent(event: Event) {
-        state.updateAdvertisingIdentifier(event: event,
-                                          createXDMSharedState: createXDMSharedState(data:event:),
-                                          eventDispatcher: dispatch(event:))
+        if event.isAdIdEvent {
+            state.updateAdvertisingIdentifier(event: event,
+                                              createXDMSharedState: createXDMSharedState(data:event:),
+                                              eventDispatcher: dispatch(event:))
+        }
     }
 
     /// Handles events requesting for identifiers. Dispatches response event containing the identifiers. Called by listener registered with event hub.

--- a/Sources/Identity.swift
+++ b/Sources/Identity.swift
@@ -32,9 +32,7 @@ import Foundation
 
     public func onRegistered() {
         registerListener(type: EventType.edgeIdentity, source: EventSource.requestIdentity, listener: handleIdentityRequest)
-        
         registerListener(type: EventType.genericIdentity, source: EventSource.requestContent, listener: handleRequestContent)
-        
         registerListener(type: EventType.edgeIdentity, source: EventSource.updateIdentity, listener: handleUpdateIdentity)
         registerListener(type: EventType.edgeIdentity, source: EventSource.removeIdentity, listener: handleRemoveIdentity)
         registerListener(type: EventType.genericIdentity, source: EventSource.requestReset, listener: handleRequestReset)

--- a/Sources/IdentityConstants.swift
+++ b/Sources/IdentityConstants.swift
@@ -25,9 +25,6 @@ enum IdentityConstants {
     }
 
     enum SharedState {
-//        static let STATE_OWNER = "stateowner"
-//        static let ADVERTISING_IDENTIFIER = "advertisingidentifier"
-
         enum Configuration {
             static let SHARED_OWNER_NAME = "com.adobe.module.configuration"
         }

--- a/Sources/IdentityConstants.swift
+++ b/Sources/IdentityConstants.swift
@@ -49,7 +49,7 @@ enum IdentityConstants {
         static let IDENTITY_RESPONSE_CONTENT_ONE_TIME = "Edge Identity Response Content One Time"
         static let RESET_IDENTITIES_COMPLETE = "Edge Identity Reset Identities Complete"
     }
-    
+
     enum EventDataKeys {
         static let ADVERTISING_IDENTIFIER = "advertisingidentifier"
         static let STATE_OWNER = "stateowner"
@@ -76,7 +76,8 @@ enum IdentityConstants {
 
         enum Consent {
             static let CONSENTS = "consents"
-            static let AD_ID = "adId"
+            static let ID_TYPE = "idType"
+            static let AD_ID = "adID"
             static let VAL = "val"
             static let YES = "y"
             static let NO = "n"

--- a/Sources/IdentityProperties.swift
+++ b/Sources/IdentityProperties.swift
@@ -82,8 +82,8 @@ struct IdentityProperties: Codable {
             }
         }
     }
-    
-    /// The IDFA from retrieved Apple APIs
+
+    /// The current Ad ID (IDFA) set with the Identity extension
     var advertisingIdentifier: String? {
         get {
             return getAdvertisingIdentifier()
@@ -193,7 +193,7 @@ struct IdentityProperties: Codable {
 
         return nil
     }
-    
+
     /// Get the advertising identifier from the properties map. Assumes only one `IdentityItem` under the "IDFA" namespace.
     /// - Returns: the advertising identifier or nil if not found
     private func getAdvertisingIdentifier() -> String? {

--- a/Sources/IdentityState.swift
+++ b/Sources/IdentityState.swift
@@ -108,7 +108,7 @@ class IdentityState {
         // update adid if changed and extract the new adid value
         let (adIdChanged, shouldUpdateConsent) = shouldUpdateAdId(newAdID: event.adId)
         if adIdChanged {
-            let adId = event.adId ?? ""
+            let adId = event.adId
             identityProperties.advertisingIdentifier = adId
 
             if shouldUpdateConsent {

--- a/Sources/IdentityState.swift
+++ b/Sources/IdentityState.swift
@@ -176,12 +176,12 @@ class IdentityState {
                           createXDMSharedState: ([String: Any], Event) -> Void,
                           eventDispatcher: (Event) -> Void) {
         let shouldDispatchConsent = identityProperties.advertisingIdentifier != nil && !(identityProperties.advertisingIdentifier?.isEmpty ?? true)
-        if shouldDispatchConsent {
-            dispatchAdIdConsentRequestEvent(val: IdentityConstants.XDMKeys.Consent.NO, eventDispatcher: eventDispatcher)
-        }
         identityProperties.clear()
         identityProperties.ecid = ECID().ecidString
 
+        if shouldDispatchConsent {
+            dispatchAdIdConsentRequestEvent(val: IdentityConstants.XDMKeys.Consent.NO, eventDispatcher: eventDispatcher)
+        }
         saveToPersistence(and: createXDMSharedState, using: event)
 
         let event = Event(name: IdentityConstants.EventNames.RESET_IDENTITIES_COMPLETE,

--- a/Sources/IdentityState.swift
+++ b/Sources/IdentityState.swift
@@ -175,13 +175,9 @@ class IdentityState {
     func resetIdentifiers(event: Event,
                           createXDMSharedState: ([String: Any], Event) -> Void,
                           eventDispatcher: (Event) -> Void) {
-        let shouldDispatchConsent = identityProperties.advertisingIdentifier != nil && !(identityProperties.advertisingIdentifier?.isEmpty ?? true)
         identityProperties.clear()
         identityProperties.ecid = ECID().ecidString
 
-        if shouldDispatchConsent {
-            dispatchAdIdConsentRequestEvent(val: IdentityConstants.XDMKeys.Consent.NO, eventDispatcher: eventDispatcher)
-        }
         saveToPersistence(and: createXDMSharedState, using: event)
 
         let event = Event(name: IdentityConstants.EventNames.RESET_IDENTITIES_COMPLETE,

--- a/Sources/IdentityState.swift
+++ b/Sources/IdentityState.swift
@@ -215,7 +215,7 @@ class IdentityState {
         let existingAdId = identityProperties.advertisingIdentifier ?? ""
 
         // did the advertising identifier change?
-        if (!newAdID.isEmpty && newAdID != existingAdId) || (newAdID.isEmpty && !existingAdId.isEmpty) {
+        if newAdID != existingAdId {
             if newAdID.isEmpty || existingAdId.isEmpty {
                 return (true, true)
             }

--- a/Sources/IdentityState.swift
+++ b/Sources/IdentityState.swift
@@ -104,7 +104,7 @@ class IdentityState {
     func updateAdvertisingIdentifier(event: Event,
                                      createXDMSharedState: ([String: Any], Event) -> Void,
                                      eventDispatcher: (Event) -> Void) {
-
+        
         // update adid if changed and extract the new adid value
         let (adIdChanged, shouldUpdateConsent) = shouldUpdateAdId(newAdID: event.adId)
         if adIdChanged {
@@ -210,26 +210,21 @@ class IdentityState {
     /// - Parameter newAdID: the new ad id
     /// - Returns: A tuple indicating if the ad id has changed, and if the consent should be updated
     private func shouldUpdateAdId(newAdID: String?) -> (adIdChanged: Bool, updateConsent: Bool) {
+        // After sanitization of event.adId, nil means event is not an AdID event
         guard let newAdID = newAdID else { return (false, false) }
-
         let existingAdId = identityProperties.advertisingIdentifier ?? ""
 
         // did the advertising identifier change?
-        if (!newAdID.isEmpty && newAdID != existingAdId)
-            || (newAdID.isEmpty && !existingAdId.isEmpty) {
-            // Now we know the value changed, but did it change to/from null?
-            // Handle case where existingAdId loaded from persistence with all zeros and new value is not empty.
-            if newAdID.isEmpty || existingAdId.isEmpty || existingAdId == IdentityConstants.Default.ZERO_ADVERTISING_ID {
+        if (!newAdID.isEmpty && newAdID != existingAdId) || (newAdID.isEmpty && !existingAdId.isEmpty) {
+            if newAdID.isEmpty || existingAdId.isEmpty {
                 return (true, true)
             }
-
             return (true, false)
         }
-
         return (false, false)
     }
 
-    /// Dispatch a consent request `Event` with `EventType.consent` and `EventSource.requestContent` which contains the consent value specifying
+    /// Dispatch a consent request `Event` with `EventType.edgeConsent` and `EventSource.updateConsent` which contains the consent value specifying
     /// new advertising tracking preferences.
     /// - Parameters:
     ///   -  val: The new adId consent value, either "y" or "n"

--- a/Sources/IdentityState.swift
+++ b/Sources/IdentityState.swift
@@ -176,12 +176,11 @@ class IdentityState {
                           createXDMSharedState: ([String: Any], Event) -> Void,
                           eventDispatcher: (Event) -> Void) {
         let shouldDispatchConsent = identityProperties.advertisingIdentifier != nil && !(identityProperties.advertisingIdentifier?.isEmpty ?? true)
-        identityProperties.clear()
-        identityProperties.ecid = ECID().ecidString
-
         if shouldDispatchConsent {
             dispatchAdIdConsentRequestEvent(val: IdentityConstants.XDMKeys.Consent.NO, eventDispatcher: eventDispatcher)
         }
+        identityProperties.clear()
+        identityProperties.ecid = ECID().ecidString
 
         saveToPersistence(and: createXDMSharedState, using: event)
 

--- a/Tests/FunctionalTests/IdentityAdIDTests.swift
+++ b/Tests/FunctionalTests/IdentityAdIDTests.swift
@@ -14,7 +14,7 @@
 import AEPServices
 import XCTest
 
-class IdentityEdgeTests: XCTestCase {
+class IdentityAdIDTests: XCTestCase {
     var identity: Identity!
 
     var mockRuntime: TestableExtensionRuntime!
@@ -165,6 +165,19 @@ class IdentityEdgeTests: XCTestCase {
 
         XCTAssertEqual(2, mockRuntime.createdXdmSharedStates.count) // bootup + request content event
         XCTAssertEqual(expectedIdentity as NSObject, mockRuntime.createdXdmSharedStates[1] as NSObject?)
+        
+        let expectedConsent: [String: Any] =
+            [
+                "consents": [
+                    "adID": [
+                        "val": "n",
+                        "idType": "IDFA"
+                    ]
+                ]
+            ]
+        XCTAssertEqual(EventType.edgeConsent, mockRuntime.dispatchedEvents[0].type)
+        XCTAssertEqual(EventSource.updateConsent, mockRuntime.dispatchedEvents[0].source)
+        XCTAssertEqual(expectedConsent as NSObject, mockRuntime.dispatchedEvents[0].data as NSObject?)
     }
     
     /// Test ad ID is updated from valid to nil, and consent event is dispatched

--- a/Tests/FunctionalTests/IdentityAdIDTests.swift
+++ b/Tests/FunctionalTests/IdentityAdIDTests.swift
@@ -30,7 +30,6 @@ class IdentityAdIDTests: XCTestCase {
     // MARK: handleIdentityRequest
     /// Test ad ID is updated from old to new valid value, and consent true is dispatched
     func testGenericIdentityRequest_whenValidAdId_thenNewValidAdId() {
-        // Save previous log filter value
         var props = IdentityProperties()
         props.ecid = ECID().ecidString
         props.advertisingIdentifier = "oldAdId"
@@ -66,7 +65,6 @@ class IdentityAdIDTests: XCTestCase {
     
     /// Test ad ID stays the same with same new valid value, and consent event is not dispatched
     func testGenericIdentityRequest_whenValidAdId_thenSameValidAdId() {
-        // Save previous log filter value
         var props = IdentityProperties()
         props.ecid = ECID().ecidString
         props.advertisingIdentifier = "oldAdId"

--- a/Tests/FunctionalTests/IdentityTests.swift
+++ b/Tests/FunctionalTests/IdentityTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 Adobe. All rights reserved.
+// Copyright 2022 Adobe. All rights reserved.
 // This file is licensed to you under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License. You may obtain a copy
 // of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -27,7 +27,7 @@ class IdentityEdgeTests: XCTestCase {
         mockRuntime = TestableExtensionRuntime()
         identity = Identity(runtime: mockRuntime)
         identity.onRegistered()
-        
+
     }
 
     // MARK: handleIdentityRequest
@@ -39,7 +39,7 @@ class IdentityEdgeTests: XCTestCase {
         props.ecid = ECID().ecidString
         props.advertisingIdentifier = "oldAdId"
         props.saveToPersistence()
-        
+
         // simulate bootup as mockRuntime bypasses call to readyForEvent
         let testEvent = Event(name: "test-event", type: "test-type", source: "test-source", data: nil)
         XCTAssertTrue(identity.readyForEvent(testEvent))
@@ -49,7 +49,6 @@ class IdentityEdgeTests: XCTestCase {
                           source: EventSource.requestContent,
                           data: [IdentityConstants.EventDataKeys.ADVERTISING_IDENTIFIER: "adId"])
 
-        
         // no longer calls bootupIfReady
         // test
         mockRuntime.simulateComingEvent(event: event)
@@ -76,7 +75,7 @@ class IdentityEdgeTests: XCTestCase {
         props.ecid = ECID().ecidString
         props.advertisingIdentifier = "oldAdId"
         props.saveToPersistence()
-        
+
         // simulate bootup as mockRuntime bypasses call to readyForEvent
         let testEvent = Event(name: "test-event", type: "test-type", source: "test-source", data: nil)
         XCTAssertTrue(identity.readyForEvent(testEvent))
@@ -98,10 +97,10 @@ class IdentityEdgeTests: XCTestCase {
                     "ECID": [["id": "\(props.ecid ?? "")", "authenticatedState": "ambiguous", "primary": 0]]
                 ]
             ]
-        
+
         XCTAssertEqual(2, mockRuntime.createdXdmSharedStates.count) // bootup + request content event
         XCTAssertEqual(expectedIdentity as NSObject, mockRuntime.createdXdmSharedStates[1] as NSObject?)
-        
+
     }
     // TODO: more e2e tests that trigger different states
     // consent integration, dispatching consent event correctly (test above will not trigger this behavior)
@@ -109,7 +108,7 @@ class IdentityEdgeTests: XCTestCase {
     // need test for not sending out consent in the case of having existing adid & updating to new one (consent hasnt changed, dont need to emit event)
     // if persisted adid is blank & pass in all 0, shouldnt dispatch (treat all 0 as a blank string; that is, value hasn't changed, and adid should be treated logically as nil)
     // test to make sure you cant set IDFA directly using update APIs or remove (should already exist, verify - updatecustomidentifiers, removeidentiteswithreservednamespaces)
-        // only way to update ADID should be setADID APIs 
+    // only way to update ADID should be setADID APIs
     // current tests show that old ad id is set/cleared correctly
     // - only testing that setting various values updates correctly; can be done through unit testing through identity properties
 }

--- a/Tests/Mocks/TestableExtensionRuntime.swift
+++ b/Tests/Mocks/TestableExtensionRuntime.swift
@@ -17,7 +17,7 @@ class TestableExtensionRuntime: ExtensionRuntime {
     func getHistoricalEvents(_ requests: [EventHistoryRequest], enforceOrder: Bool, handler: @escaping ([EventHistoryResult]) -> Void) {
         // no-op
     }
-    
+
     var listeners: [String: EventListener] = [:]
     var dispatchedEvents: [Event] = []
     var createdSharedStates: [[String: Any]?] = []

--- a/Tests/UnitTests/IdentityStateTests.swift
+++ b/Tests/UnitTests/IdentityStateTests.swift
@@ -561,15 +561,15 @@ class IdentityStateTests: XCTestCase {
         state.resetIdentifiers(event: event,
                                createXDMSharedState: { _, _ in xdmSharedStateExpectation.fulfill()
                                }, eventDispatcher: { event in
-                                   // With props.advertisingIdentifier defined at reset time, both edgeConsent and edgeIdentity hits are registered
-                                   XCTAssertTrue(testEventTypes.contains(event.type))
-                                   testEventTypes.remove(event.type)
-                                   XCTAssertTrue(testEventSources.contains(event.source))
-                                   testEventSources.remove(event.source)
-                                   
-                                   consentEvent = event
-                                   dispatchConsentExpectation.fulfill()
-                                   responseEventExpectation.fulfill()
+                                // With props.advertisingIdentifier defined at reset time, both edgeConsent and edgeIdentity hits are registered
+                                XCTAssertTrue(testEventTypes.contains(event.type))
+                                testEventTypes.remove(event.type)
+                                XCTAssertTrue(testEventSources.contains(event.source))
+                                testEventSources.remove(event.source)
+
+                                consentEvent = event
+                                dispatchConsentExpectation.fulfill()
+                                responseEventExpectation.fulfill()
                                })
 
         wait(for: [xdmSharedStateExpectation, responseEventExpectation], timeout: 2)
@@ -581,10 +581,10 @@ class IdentityStateTests: XCTestCase {
         XCTAssertNil(state.identityProperties.identityMap.getItems(withNamespace: "space"))
         XCTAssertNotNil(state.identityProperties.ecid)
         XCTAssertNotEqual(props.ecid, state.identityProperties.ecid)
-        
+
         XCTAssertNotNil(consentEvent)
         // TODO: Uncomment and test when consent y/n implemented
-//        XCTAssertEqual("n", ((consentEvent?.data?["consents"] as? [String: Any])?["adId"] as? [String: Any])?["val"] as? String)
+        //        XCTAssertEqual("n", ((consentEvent?.data?["consents"] as? [String: Any])?["adId"] as? [String: Any])?["val"] as? String)
     }
 
     private func addEcidToIdentityDirectPersistence(ecid: ECID?) {
@@ -592,7 +592,7 @@ class IdentityStateTests: XCTestCase {
         let jsonData = try? JSONEncoder().encode(data)
         mockDataStore.dict["identity.properties"] = jsonData
     }
-    
+
     func testResetIdentitiesAdIdIsEmptyDoesNotDispatchConsentEvent() {
         var props = IdentityProperties()
         props.advertisingIdentifier = ""
@@ -609,12 +609,12 @@ class IdentityStateTests: XCTestCase {
         state.resetIdentifiers(event: event,
                                createXDMSharedState: { _, _ in xdmSharedStateExpectation.fulfill() },
                                eventDispatcher: { event in
-                                    // Checking both the expected hit and that consent request event not sent
-                                    XCTAssertTrue(event.type == EventType.edgeIdentity && event.source == EventSource.resetComplete)
-                                    if event.type == EventType.edgeConsent && event.source == EventSource.updateConsent {
-                                        XCTFail("Consent request event should not be dispatched")
-                                    }
-                                })
+                                // Checking both the expected hit and that consent request event not sent
+                                XCTAssertTrue(event.type == EventType.edgeIdentity && event.source == EventSource.resetComplete)
+                                if event.type == EventType.edgeConsent && event.source == EventSource.updateConsent {
+                                    XCTFail("Consent request event should not be dispatched")
+                                }
+                               })
 
         wait(for: [xdmSharedStateExpectation], timeout: 1)
         XCTAssertFalse(mockDataStore.dict.isEmpty) // identity properties should have been saved to persistence
@@ -637,11 +637,11 @@ class IdentityStateTests: XCTestCase {
         state.resetIdentifiers(event: event,
                                createXDMSharedState: { _, _ in xdmSharedStateExpectation.fulfill() },
                                eventDispatcher: { event in
-                                    // Checking both the expected hit and that consent request event not sent
-                                    XCTAssertTrue(event.type == EventType.edgeIdentity && event.source == EventSource.resetComplete)
-                                    if event.type == EventType.edgeConsent && event.source == EventSource.updateConsent {
-                                        XCTFail("Consent request event should not be dispatched")
-                                    }
+                                // Checking both the expected hit and that consent request event not sent
+                                XCTAssertTrue(event.type == EventType.edgeIdentity && event.source == EventSource.resetComplete)
+                                if event.type == EventType.edgeConsent && event.source == EventSource.updateConsent {
+                                    XCTFail("Consent request event should not be dispatched")
+                                }
                                })
 
         wait(for: [xdmSharedStateExpectation], timeout: 1)
@@ -746,7 +746,7 @@ class IdentityStateTests: XCTestCase {
         XCTAssertEqual(expectedAdId, state.identityProperties.advertisingIdentifier)
 
         XCTAssertNotNil(consentEvent)
-        XCTAssertEqual(expectedConsent, ((consentEvent?.data?["consents"] as? [String: Any])?["adId"] as? [String: Any])?["val"] as? String)
+        XCTAssertEqual(expectedConsent, ((consentEvent?.data?[IdentityConstants.XDMKeys.Consent.CONSENTS] as? [String: Any])?[IdentityConstants.XDMKeys.Consent.AD_ID] as? [String: Any])?[IdentityConstants.XDMKeys.Consent.VAL] as? String)
     }
 
     private func assertUpdateAdvertisingIdentifierIsUpdatedWithoutConsentChange(persistedAdId: String?, newAdId: String?, expectedAdId: String?) {
@@ -794,7 +794,7 @@ private extension Event {
     static func fakeIdentityEvent() -> Event {
         return Event(name: "Fake Identity Event", type: EventType.edgeIdentity, source: EventSource.requestContent, data: nil)
     }
-    
+
     static func fakeGenericIdentityEvent(adId: String?) -> Event {
         return Event(name: "Test Event",
                      type: EventType.genericIdentity,

--- a/Tests/UnitTests/IdentityStateTests.swift
+++ b/Tests/UnitTests/IdentityStateTests.swift
@@ -716,11 +716,6 @@ class IdentityStateTests: XCTestCase {
         assertUpdateAdvertisingIdentifierIsUpdatedWithConsentChange(persistedAdId: IdentityConstants.Default.ZERO_ADVERTISING_ID, newAdId: IdentityConstants.Default.ZERO_ADVERTISING_ID, expectedAdId: nil, expectedConsent: "n")
     }
 
-    /// Test ad ID call is ignored if passing nil
-//    func testUpdateAdvertisingIdentifierPassingNilIsIgnored() {
-//        assertUpdateAdvertisingIdentifierIsNotUpdated(persistedAdId: "oldAdId", newAdId: nil, expectedAdId: "oldAdId")
-//    }
-
     private func assertUpdateAdvertisingIdentifierIsUpdatedWithConsentChange(persistedAdId: String?, newAdId: String?, expectedAdId: String?, expectedConsent: String?) {
         // setup
         let xdmSharedStateExpectation = XCTestExpectation(description: "XDM shared state should be updated once")

--- a/Tests/UnitTests/IdentityStateTests.swift
+++ b/Tests/UnitTests/IdentityStateTests.swift
@@ -567,12 +567,9 @@ class IdentityStateTests: XCTestCase {
 
         wait(for: [xdmSharedStateExpectation, dispatchedEventsExpectation], timeout: 2)
         
-        // Verify Event type and source pairs, and the correct ordering
-        // 1. Update consent event
-        // 2. Reset identity request
+        // Verify Event type and source pairs
+        // Reset identity request
         XCTAssertEqual(1, dispatchedEvents.count)
-//        XCTAssertEqual(EventType.edgeConsent, dispatchedEvents[0].type)
-//        XCTAssertEqual(EventSource.updateConsent, dispatchedEvents[0].source)
         XCTAssertEqual(EventType.edgeIdentity, dispatchedEvents[0].type)
         XCTAssertEqual(EventSource.resetComplete, dispatchedEvents[0].source)
         

--- a/Tests/UnitTests/IdentityStateTests.swift
+++ b/Tests/UnitTests/IdentityStateTests.swift
@@ -703,12 +703,6 @@ class IdentityStateTests: XCTestCase {
     }
 
     // Starting from all-zeros
-    /// Test ad ID is updated from all zeros to valid value and consent is not dispatched.
-    /// This is a special case because all-zero in persistence should not be possible because all incoming ad ID values should be sanitized to ""
-    func testUpdateAdvertisingIdentifier_whenAllZeros_thenChangedToValid() {
-        assertUpdateAdvertisingIdentifierIsUpdatedWithoutConsentChange(persistedAdId: IdentityConstants.Default.ZERO_ADVERTISING_ID, newAdId: "adId", expectedAdId: "adId")
-    }
-    
     /// Test ad ID is updated from all zeros to empty string and consent false is dispatched
     func testUpdateAdvertisingIdentifier_whenAllZeros_thenChangedToEmpty() {
         assertUpdateAdvertisingIdentifierIsUpdatedWithConsentChange(persistedAdId: IdentityConstants.Default.ZERO_ADVERTISING_ID, newAdId: "", expectedAdId: nil, expectedConsent: "n")

--- a/Tests/UnitTests/IdentityStateTests.swift
+++ b/Tests/UnitTests/IdentityStateTests.swift
@@ -567,21 +567,14 @@ class IdentityStateTests: XCTestCase {
 
         wait(for: [xdmSharedStateExpectation, dispatchedEventsExpectation], timeout: 2)
         
-        // Tuples allow for event type and source to be explicitly paired
-        // Update consent event
-        // Reset identity request
-        var eventCheck = [
-            (type: EventType.edgeConsent, source: EventSource.updateConsent),
-            (type: EventType.edgeIdentity, source: EventSource.resetComplete)
-        ]
-        
-        for event in dispatchedEvents {
-            if let foundIndex = eventCheck.firstIndex(where: { $0.type == event.type && $0.source == event.source }) {
-                eventCheck.remove(at: foundIndex)
-            }
-        }
-        
-        XCTAssertTrue(eventCheck.isEmpty)
+        // Verify Event type and source pairs, and the correct ordering
+        // 1. Update consent event
+        // 2. Reset identity request
+        XCTAssertEqual(2, dispatchedEvents.count)
+        XCTAssertEqual(EventType.edgeConsent, dispatchedEvents[0].type)
+        XCTAssertEqual(EventSource.updateConsent, dispatchedEvents[0].source)
+        XCTAssertEqual(EventType.edgeIdentity, dispatchedEvents[1].type)
+        XCTAssertEqual(EventSource.resetComplete, dispatchedEvents[1].source)
         
         XCTAssertFalse(mockDataStore.dict.isEmpty) // identity properties should have been saved to persistence
         XCTAssertNil(state.identityProperties.advertisingIdentifier)
@@ -724,9 +717,9 @@ class IdentityStateTests: XCTestCase {
     }
 
     /// Test ad ID call is ignored if passing nil
-    func testUpdateAdvertisingIdentifierPassingNilIsIgnored() {
-        assertUpdateAdvertisingIdentifierIsNotUpdated(persistedAdId: "oldAdId", newAdId: nil, expectedAdId: "oldAdId")
-    }
+//    func testUpdateAdvertisingIdentifierPassingNilIsIgnored() {
+//        assertUpdateAdvertisingIdentifierIsNotUpdated(persistedAdId: "oldAdId", newAdId: nil, expectedAdId: "oldAdId")
+//    }
 
     private func assertUpdateAdvertisingIdentifierIsUpdatedWithConsentChange(persistedAdId: String?, newAdId: String?, expectedAdId: String?, expectedConsent: String?) {
         // setup

--- a/Tests/UnitTests/IdentityStateTests.swift
+++ b/Tests/UnitTests/IdentityStateTests.swift
@@ -651,68 +651,71 @@ class IdentityStateTests: XCTestCase {
     }
 
     // MARK: updateAdvertisingIdentifier(...)
+    // Starting from nil
     /// Test ad ID is updated from nil to valid value on first call, and consent true is dispatched
-    func testUpdateAdvertisingIdentifierUpdatesNilWithValidId() {
+    func testUpdateAdvertisingIdentifier_whenNil_thenChangedToValid() {
         assertUpdateAdvertisingIdentifierIsUpdatedWithConsentChange(persistedAdId: nil, newAdId: "adId", expectedAdId: "adId", expectedConsent: "y")
     }
 
     /// Test ad ID is updated from nil to empty on first call, and consent false is dispatched
-    func testUpdateAdvertisingIdentifierUpdatesNilWithEmptyId() {
+    func testUpdateAdvertisingIdentifier_whenNil_thenChangedToEmpty() {
         assertUpdateAdvertisingIdentifierIsNotUpdated(persistedAdId: nil, newAdId: "", expectedAdId: nil)
     }
 
     /// Test ad ID is updated from nil to empty on first call when all zeros is passed, and consent false is dispatched
-    func testUpdateAdvertisingIdentifierUpdatesNilWithZeros() {
+    func testUpdateAdvertisingIdentifier_whenNil_thenChangedToAllZeros() {
         assertUpdateAdvertisingIdentifierIsNotUpdated(persistedAdId: nil, newAdId: IdentityConstants.Default.ZERO_ADVERTISING_ID, expectedAdId: nil)
     }
-
+    // Starting from ""
     /// Test ad ID is updated from empty to valid value and consent true is dispatched
-    func testUpdateAdvertisingIdentifierUpdatesEmptyWithValidId() {
+    func testUpdateAdvertisingIdentifier_whenEmpty_thenChangedToValid() {
         assertUpdateAdvertisingIdentifierIsUpdatedWithConsentChange(persistedAdId: "", newAdId: "adId", expectedAdId: "adId", expectedConsent: "y")
     }
 
     /// Test ad ID call is ignored when old and new values are empty
-    func testUpdateAdvertisingIdentifierDoesNotUpdatesEmptyWithEmpty() {
+    func testUpdateAdvertisingIdentifier_whenEmpty_thenSameValue() {
         assertUpdateAdvertisingIdentifierIsNotUpdated(persistedAdId: "", newAdId: "", expectedAdId: nil)
     }
 
     /// Test ad ID call is ignored when old and new values are empty; passing all zeros is converted to empty string
-    func testUpdateAdvertisingIdentifierDoesNotUpdatesEmptyWithEZeros() {
+    func testUpdateAdvertisingIdentifier_whenEmpty_thenChangedToAllZeros() {
         assertUpdateAdvertisingIdentifierIsNotUpdated(persistedAdId: "", newAdId: IdentityConstants.Default.ZERO_ADVERTISING_ID, expectedAdId: nil)
     }
-
+    // Starting from valid
     /// Test ad ID is updated from old value to new value, and no consent event is dispatched
-    func testUpdateAdvertisingIdentifierUpdatesValidWithNewValidId() {
+    func testUpdateAdvertisingIdentifier_whenValid_thenChangedToNewValid() {
         assertUpdateAdvertisingIdentifierIsUpdatedWithoutConsentChange(persistedAdId: "oldAdId", newAdId: "adId", expectedAdId: "adId")
     }
 
     /// Test ad ID is not updated when old and new values are the same
-    func testUpdateAdvertisingIdentifierDoesNotUpdatesValidWithSameValidId() {
+    func testUpdateAdvertisingIdentifier_whenValid_thenSameValue() {
         assertUpdateAdvertisingIdentifierIsNotUpdated(persistedAdId: "adId", newAdId: "adId", expectedAdId: "adId")
     }
 
     /// Test ad ID is updated from valid value to empty string and consent false is dispatched
-    func testUpdateAdvertisingIdentifierUpdatesValidWithEmptyId() {
+    func testUpdateAdvertisingIdentifier_whenValid_thenChangedToEmpty() {
         assertUpdateAdvertisingIdentifierIsUpdatedWithConsentChange(persistedAdId: "oldAdId", newAdId: "", expectedAdId: nil, expectedConsent: "n")
     }
 
     /// Test ad ID is updaed from valid value to empty string when all zeros is passed, and consent false is dispatched
-    func testUpdateAdvertisingIdentifierUpdatesValidWithZeros() {
+    func testUpdateAdvertisingIdentifier_whenValid_thenChangedToAllZeros() {
         assertUpdateAdvertisingIdentifierIsUpdatedWithConsentChange(persistedAdId: "oldAdId", newAdId: IdentityConstants.Default.ZERO_ADVERTISING_ID, expectedAdId: nil, expectedConsent: "n")
     }
 
-    /// Test ad ID is updaed from all zeros to valid value and consent true is dispatched
-//    func testUpdateAdvertisingIdentifierUpdatesZerosWithValidId() {
-//        assertUpdateAdvertisingIdentifierIsUpdatedWithConsentChange(persistedAdId: IdentityConstants.Default.ZERO_ADVERTISING_ID, newAdId: "adId", expectedAdId: "adId", expectedConsent: "y")
-//    }
-
+    // Starting from all-zeros
+    /// Test ad ID is updated from all zeros to valid value and consent is not dispatched.
+    /// This is a special case because all-zero in persistence should not be possible because all incoming ad ID values should be sanitized to ""
+    func testUpdateAdvertisingIdentifier_whenAllZeros_thenChangedToValid() {
+        assertUpdateAdvertisingIdentifierIsUpdatedWithoutConsentChange(persistedAdId: IdentityConstants.Default.ZERO_ADVERTISING_ID, newAdId: "adId", expectedAdId: "adId")
+    }
+    
     /// Test ad ID is updated from all zeros to empty string and consent false is dispatched
-    func testUpdateAdvertisingIdentifierUpdatesZerosWithEmptyId() {
+    func testUpdateAdvertisingIdentifier_whenAllZeros_thenChangedToEmpty() {
         assertUpdateAdvertisingIdentifierIsUpdatedWithConsentChange(persistedAdId: IdentityConstants.Default.ZERO_ADVERTISING_ID, newAdId: "", expectedAdId: nil, expectedConsent: "n")
     }
 
     /// Test ad ID is updated from all zeros to empty string and consent false is dispatched; passing all zeros is converted to empty string
-    func testUpdateAdvertisingIdentifierUpdatesZerosWithZeros() {
+    func testUpdateAdvertisingIdentifier_whenAllZeros_thenSameValue() {
         assertUpdateAdvertisingIdentifierIsUpdatedWithConsentChange(persistedAdId: IdentityConstants.Default.ZERO_ADVERTISING_ID, newAdId: IdentityConstants.Default.ZERO_ADVERTISING_ID, expectedAdId: nil, expectedConsent: "n")
     }
 

--- a/Tests/UnitTests/IdentityTests.swift
+++ b/Tests/UnitTests/IdentityTests.swift
@@ -71,7 +71,7 @@ class IdentityTests: XCTestCase {
         XCTAssertNotNil(responseEvent)
         XCTAssertNotNil(responseEvent?.data)
     }
-    
+
     // MARK: handleRequestContent
     /// Tests that when identity receives a generic identity request content event with an advertising ID, that the ID is updated
     func testGenericIdentityRequestWithAdId() {

--- a/Tests/UnitTests/IdentityTests.swift
+++ b/Tests/UnitTests/IdentityTests.swift
@@ -101,7 +101,7 @@ class IdentityTests: XCTestCase {
         XCTAssertEqual("newAdId", identity.state.identityProperties.advertisingIdentifier)
     }
     
-    /// Tests that when identity receives a generic identity request content event with a `nil` advertising ID, that the ID is removed
+    /// Tests that when identity receives a generic identity request content event with a `nil` advertising ID, that the ID is not changed
     func testGenericIdentityRequestWithNilAdIdWithValidId() {
         // setup
         identity.state.identityProperties.advertisingIdentifier = "AdID"

--- a/Tests/UnitTests/IdentityTests.swift
+++ b/Tests/UnitTests/IdentityTests.swift
@@ -102,21 +102,21 @@ class IdentityTests: XCTestCase {
     }
     
     /// Tests that when identity receives a generic identity request content event with a `nil` advertising ID, that the ID is removed
-//    func testGenericIdentityRequestWithNilAdIdWithValidId() {
-//        // setup
-//        identity.state.identityProperties.advertisingIdentifier = "AdID"
-//        let event = Event(name: "Test Request Content",
-//                          type: EventType.genericIdentity,
-//                          source: EventSource.requestContent,
-//                          data: [IdentityConstants.EventDataKeys.ADVERTISING_IDENTIFIER: NSNull()] as [String: Any])
-//        // test
-//        mockRuntime.simulateComingEvent(event: event)
-//
-//        // verify
-//        XCTAssertNil(identity.state.identityProperties.advertisingIdentifier)
-//    }
+    func testGenericIdentityRequestWithNilAdIdWithValidId() {
+        // setup
+        identity.state.identityProperties.advertisingIdentifier = "AdID"
+        let event = Event(name: "Test Request Content",
+                          type: EventType.genericIdentity,
+                          source: EventSource.requestContent,
+                          data: [IdentityConstants.EventDataKeys.ADVERTISING_IDENTIFIER: Optional<String>.none as Any] as [String: Any])
+        // test
+        mockRuntime.simulateComingEvent(event: event)
 
-    /// Tests that when identity receives a generic identity request content event without an advertising ID, that the ID is not changed
+        // verify
+        XCTAssertNotNil(identity.state.identityProperties.advertisingIdentifier)
+    }
+
+    /// Tests that when identity receives a generic identity request content event **without** an advertising ID, that the ID is not changed
     func testGenericIdentityRequestWithoutAdIdWithValidId() {
         // setup
         identity.state.identityProperties.advertisingIdentifier = "AdID"
@@ -131,7 +131,7 @@ class IdentityTests: XCTestCase {
         XCTAssertEqual("AdID", identity.state.identityProperties.advertisingIdentifier)
     }
     
-    /// Tests that when identity receives a generic identity request content event without an advertising ID, that the ID is not changed
+    /// Tests that when identity receives a generic identity request content event **without** an advertising ID, that the ID is not changed
     func testGenericIdentityRequestWithoutAdIdWithoutValidId() {
         // setup
         let event = Event(name: "Test Request Content",

--- a/Tests/UnitTests/IdentityTests.swift
+++ b/Tests/UnitTests/IdentityTests.swift
@@ -74,7 +74,21 @@ class IdentityTests: XCTestCase {
 
     // MARK: handleRequestContent
     /// Tests that when identity receives a generic identity request content event with an advertising ID, that the ID is updated
-    func testGenericIdentityRequestWithAdId() {
+    func testGenericIdentityRequestWithAdIdWithValidId() {
+        // setup
+        identity.state.identityProperties.advertisingIdentifier = "AdID"
+        let event = Event(name: "Test Request Content",
+                          type: EventType.genericIdentity,
+                          source: EventSource.requestContent,
+                          data: [IdentityConstants.EventDataKeys.ADVERTISING_IDENTIFIER: "newAdId"] as [String: Any])
+        // test
+        mockRuntime.simulateComingEvent(event: event)
+
+        // verify
+        XCTAssertEqual("newAdId", identity.state.identityProperties.advertisingIdentifier)
+    }
+    /// Tests that when identity receives a generic identity request content event **without** an advertising ID, that the ID is updated
+    func testGenericIdentityRequestWithAdIdWithoutValidId() {
         // setup
         let event = Event(name: "Test Request Content",
                           type: EventType.genericIdentity,
@@ -86,9 +100,39 @@ class IdentityTests: XCTestCase {
         // verify
         XCTAssertEqual("newAdId", identity.state.identityProperties.advertisingIdentifier)
     }
+    
+    /// Tests that when identity receives a generic identity request content event with a `nil` advertising ID, that the ID is removed
+//    func testGenericIdentityRequestWithNilAdIdWithValidId() {
+//        // setup
+//        identity.state.identityProperties.advertisingIdentifier = "AdID"
+//        let event = Event(name: "Test Request Content",
+//                          type: EventType.genericIdentity,
+//                          source: EventSource.requestContent,
+//                          data: [IdentityConstants.EventDataKeys.ADVERTISING_IDENTIFIER: NSNull()] as [String: Any])
+//        // test
+//        mockRuntime.simulateComingEvent(event: event)
+//
+//        // verify
+//        XCTAssertNil(identity.state.identityProperties.advertisingIdentifier)
+//    }
 
     /// Tests that when identity receives a generic identity request content event without an advertising ID, that the ID is not changed
-    func testGenericIdentityRequestWithoutAdId() {
+    func testGenericIdentityRequestWithoutAdIdWithValidId() {
+        // setup
+        identity.state.identityProperties.advertisingIdentifier = "AdID"
+        let event = Event(name: "Test Request Content",
+                          type: EventType.genericIdentity,
+                          source: EventSource.requestContent,
+                          data: ["someKey": "someValue"] as [String: Any])
+        // test
+        mockRuntime.simulateComingEvent(event: event)
+
+        // verify
+        XCTAssertEqual("AdID", identity.state.identityProperties.advertisingIdentifier)
+    }
+    
+    /// Tests that when identity receives a generic identity request content event without an advertising ID, that the ID is not changed
+    func testGenericIdentityRequestWithoutAdIdWithoutValidId() {
         // setup
         let event = Event(name: "Test Request Content",
                           type: EventType.genericIdentity,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Update pod dependencies to latest versions - created stub for new `getHistoricalEvents(requests:enforceOrder:handler:)` method required by `ExtensionRuntime` protocol in latest AEPCore (3.4.0) 
- Update `IdentityConstants` to have `EventDataKeys` enum with `STATE_OWNER` (moved from `SharedState`) and `ADVERTISING_IDENTIFIER`
- Migrate all tests from original feature branch
- Update variable/class names to reflect naming convention changes

In IdentityStateTests.swift:
`testResetIdentitiesAdIdIsEmptyDoesNotDispatchConsentEvent()`
`testResetIdentitiesAdIdIsNilDoesNotDispatchConsentEvent()`
Identity extension appears to send an event with
`EventType.edgeIdentity` & `EventSource.resetComplete`
On `state.resetIdentifiers` which based on the test from the feature branch, it did not do before; the two tests have been updated to look specifically for the reset event dispatched by Identity and also explicitly fail if they detect `EventType.edgeConsent` and `EventSource.updateConsent`. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
