### PR TITLE
Adding log for trying to update identifiers for ad ID reserved namespaces

### DIFF
--- a/Sources/IdentityProperties.swift
+++ b/Sources/IdentityProperties.swift
@@ -214,7 +214,8 @@ struct IdentityProperties: Codable {
             for namespace in identifiersMap.namespaces where namespace.caseInsensitiveCompare(reservedNamespace) == .orderedSame {
                 if let items = identifiersMap.getItems(withNamespace: namespace) {
                     if [IdentityConstants.Namespaces.IDFA, IdentityConstants.Namespaces.GAID].contains(namespace) {
-                        let logMessage = "IdentityProperties - Modifying identifiers in namespace '\(namespace)' is not allowed through this API; use MobileCore.setAdvertisingIdentifier instead."
+                        let logMessage = "IdentityProperties - Modifying identifiers in namespace '\(namespace)' not allowed through this API;"
+                        + " use MobileCore.setAdvertisingIdentifier instead."
                         Log.warning(label: IdentityConstants.LOG_TAG, logMessage)
                     } else {
                         Log.debug(label: IdentityConstants.LOG_TAG, "IdentityProperties - Adding/Updating identifiers in namespace '\(namespace)' is not allowed.")

--- a/Sources/IdentityProperties.swift
+++ b/Sources/IdentityProperties.swift
@@ -214,8 +214,7 @@ struct IdentityProperties: Codable {
             for namespace in identifiersMap.namespaces where namespace.caseInsensitiveCompare(reservedNamespace) == .orderedSame {
                 if let items = identifiersMap.getItems(withNamespace: namespace) {
                     if [IdentityConstants.Namespaces.IDFA, IdentityConstants.Namespaces.GAID].contains(namespace) {
-                        let logMessage = "IdentityProperties - Modifying identifiers in namespace '\(namespace)' not allowed through this API;"
-                        + " use MobileCore.setAdvertisingIdentifier instead."
+                        let logMessage = "IdentityProperties - Operation not allowed for namespace '\(namespace)'; use MobileCore.setAdvertisingIdentifier instead."
                         Log.warning(label: IdentityConstants.LOG_TAG, logMessage)
                     } else {
                         Log.debug(label: IdentityConstants.LOG_TAG, "IdentityProperties - Adding/Updating identifiers in namespace '\(namespace)' is not allowed.")

--- a/Sources/IdentityProperties.swift
+++ b/Sources/IdentityProperties.swift
@@ -214,11 +214,8 @@ struct IdentityProperties: Codable {
             for namespace in identifiersMap.namespaces where namespace.caseInsensitiveCompare(reservedNamespace) == .orderedSame {
                 if let items = identifiersMap.getItems(withNamespace: namespace) {
                     if [IdentityConstants.Namespaces.IDFA, IdentityConstants.Namespaces.GAID].contains(namespace) {
-                        let logMessage = """
-                        IdentityProperties - Adding/Updating identifiers in namespace ‘\(namespace)’ is
-                        not allowed through this API; use MobileCore.setAdvertisingIdentifier instead.
-                        """
-                        Log.debug(label: IdentityConstants.LOG_TAG, logMessage)
+                        let logMessage = "IdentityProperties - Modifying identifiers in namespace ‘\(namespace)’ is not allowed through this API; use MobileCore.setAdvertisingIdentifier instead."
+                        Log.warning(label: IdentityConstants.LOG_TAG, logMessage)
                     } else {
                         Log.debug(label: IdentityConstants.LOG_TAG, "IdentityProperties - Adding/Updating identifiers in namespace '\(namespace)' is not allowed.")
                     }

--- a/Sources/IdentityProperties.swift
+++ b/Sources/IdentityProperties.swift
@@ -213,7 +213,15 @@ struct IdentityProperties: Codable {
         for reservedNamespace in IdentityProperties.reservedNamespaces {
             for namespace in identifiersMap.namespaces where namespace.caseInsensitiveCompare(reservedNamespace) == .orderedSame {
                 if let items = identifiersMap.getItems(withNamespace: namespace) {
-                    Log.debug(label: IdentityConstants.LOG_TAG, "IdentityProperties - Adding/Updating identifiers in namespace '\(namespace)' is not allowed.")
+                    if [IdentityConstants.Namespaces.IDFA, IdentityConstants.Namespaces.GAID].contains(namespace) {
+                        let logMessage = """
+                        IdentityProperties - Adding/Updating identifiers in namespace ‘\(namespace)’ is
+                        not allowed through this API; use MobileCore.setAdvertisingIdentifier instead.
+                        """
+                        Log.debug(label: IdentityConstants.LOG_TAG, logMessage)
+                    } else {
+                        Log.debug(label: IdentityConstants.LOG_TAG, "IdentityProperties - Adding/Updating identifiers in namespace '\(namespace)' is not allowed.")
+                    }
                     for item in items {
                         filterItems.add(item: item, withNamespace: namespace)
                     }

--- a/Sources/IdentityProperties.swift
+++ b/Sources/IdentityProperties.swift
@@ -214,7 +214,7 @@ struct IdentityProperties: Codable {
             for namespace in identifiersMap.namespaces where namespace.caseInsensitiveCompare(reservedNamespace) == .orderedSame {
                 if let items = identifiersMap.getItems(withNamespace: namespace) {
                     if [IdentityConstants.Namespaces.IDFA, IdentityConstants.Namespaces.GAID].contains(namespace) {
-                        let logMessage = "IdentityProperties - Modifying identifiers in namespace ‘\(namespace)’ is not allowed through this API; use MobileCore.setAdvertisingIdentifier instead."
+                        let logMessage = "IdentityProperties - Modifying identifiers in namespace '\(namespace)' is not allowed through this API; use MobileCore.setAdvertisingIdentifier instead."
                         Log.warning(label: IdentityConstants.LOG_TAG, logMessage)
                     } else {
                         Log.debug(label: IdentityConstants.LOG_TAG, "IdentityProperties - Adding/Updating identifiers in namespace '\(namespace)' is not allowed.")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adding log for `removeIdentitiesWithReservedNamespaces` for ad ID reserved namespaces specifically, to provide a hint for which API to use. Other reserved namespaces use existing log statement.


