### PR TITLE
iOS 18 test updates

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -24,13 +24,13 @@ end
 
 target 'UnitTests' do
   core_pods
-  pod 'AEPTestUtils', :git => 'https://github.com/adobe/aepsdk-testutils-ios.git', :tag => '5.0.2'
+  pod 'AEPTestUtils', :git => 'https://github.com/adobe/aepsdk-testutils-ios.git', :tag => '5.1.0'
 end
 
 target 'FunctionalTests' do
   core_pods
   pod 'AEPIdentity'
-  pod 'AEPTestUtils', :git => 'https://github.com/adobe/aepsdk-testutils-ios.git', :tag => '5.0.2'
+  pod 'AEPTestUtils', :git => 'https://github.com/adobe/aepsdk-testutils-ios.git', :tag => '5.1.0'
 end
 
 target 'TestApp' do

--- a/Podfile
+++ b/Podfile
@@ -24,13 +24,13 @@ end
 
 target 'UnitTests' do
   core_pods
-  pod 'AEPTestUtils', :git => 'https://github.com/adobe/aepsdk-testutils-ios.git', :tag => '5.0.0'
+  pod 'AEPTestUtils', :git => 'https://github.com/adobe/aepsdk-testutils-ios.git', :tag => '5.0.2'
 end
 
 target 'FunctionalTests' do
   core_pods
   pod 'AEPIdentity'
-  pod 'AEPTestUtils', :git => 'https://github.com/adobe/aepsdk-testutils-ios.git', :tag => '5.0.0'
+  pod 'AEPTestUtils', :git => 'https://github.com/adobe/aepsdk-testutils-ios.git', :tag => '5.0.2'
 end
 
 target 'TestApp' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -17,7 +17,7 @@ PODS:
     - AEPCore (< 6.0.0, >= 5.2.0)
   - AEPRulesEngine (5.0.0)
   - AEPServices (5.2.0)
-  - AEPTestUtils (5.0.2):
+  - AEPTestUtils (5.1.0):
     - AEPCore (>= 5.2.0)
     - AEPServices (>= 5.2.0)
   - SwiftLint (0.52.0)
@@ -30,7 +30,7 @@ DEPENDENCIES:
   - AEPEdgeIdentity (from `./AEPEdgeIdentity.podspec`)
   - AEPIdentity
   - AEPServices
-  - AEPTestUtils (from `https://github.com/adobe/aepsdk-testutils-ios.git`, tag `5.0.2`)
+  - AEPTestUtils (from `https://github.com/adobe/aepsdk-testutils-ios.git`, tag `5.1.0`)
   - SwiftLint (= 0.52.0)
 
 SPEC REPOS:
@@ -49,12 +49,12 @@ EXTERNAL SOURCES:
     :path: "./AEPEdgeIdentity.podspec"
   AEPTestUtils:
     :git: https://github.com/adobe/aepsdk-testutils-ios.git
-    :tag: 5.0.2
+    :tag: 5.1.0
 
 CHECKOUT OPTIONS:
   AEPTestUtils:
     :git: https://github.com/adobe/aepsdk-testutils-ios.git
-    :tag: 5.0.2
+    :tag: 5.1.0
 
 SPEC CHECKSUMS:
   AEPAssurance: df04baeace42befb0cc213fd6cdfe51651d11ba6
@@ -65,9 +65,9 @@ SPEC CHECKSUMS:
   AEPIdentity: 3c597ef3d734d726f6a48ae10cdecb36fbeb28ca
   AEPRulesEngine: fe5800653a4bee07b1e41e61b4d5551f0dba557b
   AEPServices: d959143d13fde7e8464c19527df6baacdef765ce
-  AEPTestUtils: ef5a4f6cf9ef61630b7c68b5d205bb885a6f19a2
+  AEPTestUtils: b2c941b4f72deaff090e3e82b8c1ac31fedc1c84
   SwiftLint: 13280e21cdda6786ad908dc6e416afe5acd1fcb7
 
-PODFILE CHECKSUM: 1696457ba4a3362bd146f2959cfa55cb6a71618e
+PODFILE CHECKSUM: 8b76d31f49566b61aef3f39733d9e2f91f96a575
 
 COCOAPODS: 1.14.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,25 +1,25 @@
 PODS:
-  - AEPAssurance (5.0.0):
+  - AEPAssurance (5.0.1):
     - AEPCore (< 6.0.0, >= 5.0.0)
     - AEPServices (< 6.0.0, >= 5.0.0)
-  - AEPCore (5.0.0):
+  - AEPCore (5.2.0):
     - AEPRulesEngine (< 6.0.0, >= 5.0.0)
-    - AEPServices (< 6.0.0, >= 5.0.0)
-  - AEPEdge (5.0.0):
-    - AEPCore (< 6.0.0, >= 5.0.0)
+    - AEPServices (< 6.0.0, >= 5.2.0)
+  - AEPEdge (5.0.2):
+    - AEPCore (< 6.0.0, >= 5.1.0)
     - AEPEdgeIdentity (< 6.0.0, >= 5.0.0)
   - AEPEdgeConsent (5.0.0):
     - AEPCore (< 6.0.0, >= 5.0.0)
     - AEPEdge (< 6.0.0, >= 5.0.0)
   - AEPEdgeIdentity (5.0.0):
     - AEPCore (< 6.0.0, >= 5.0.0)
-  - AEPIdentity (5.0.0):
-    - AEPCore (< 6.0.0, >= 5.0.0)
+  - AEPIdentity (5.2.0):
+    - AEPCore (< 6.0.0, >= 5.2.0)
   - AEPRulesEngine (5.0.0)
-  - AEPServices (5.0.0)
-  - AEPTestUtils (5.0.0):
-    - AEPCore
-    - AEPServices
+  - AEPServices (5.2.0)
+  - AEPTestUtils (5.0.2):
+    - AEPCore (>= 5.2.0)
+    - AEPServices (>= 5.2.0)
   - SwiftLint (0.52.0)
 
 DEPENDENCIES:
@@ -30,7 +30,7 @@ DEPENDENCIES:
   - AEPEdgeIdentity (from `./AEPEdgeIdentity.podspec`)
   - AEPIdentity
   - AEPServices
-  - AEPTestUtils (from `https://github.com/adobe/aepsdk-testutils-ios.git`, tag `5.0.0`)
+  - AEPTestUtils (from `https://github.com/adobe/aepsdk-testutils-ios.git`, tag `5.0.2`)
   - SwiftLint (= 0.52.0)
 
 SPEC REPOS:
@@ -49,25 +49,25 @@ EXTERNAL SOURCES:
     :path: "./AEPEdgeIdentity.podspec"
   AEPTestUtils:
     :git: https://github.com/adobe/aepsdk-testutils-ios.git
-    :tag: 5.0.0
+    :tag: 5.0.2
 
 CHECKOUT OPTIONS:
   AEPTestUtils:
     :git: https://github.com/adobe/aepsdk-testutils-ios.git
-    :tag: 5.0.0
+    :tag: 5.0.2
 
 SPEC CHECKSUMS:
-  AEPAssurance: 7f260ded4df38a70a06efebade8c33a3e3221984
-  AEPCore: f1c3e9238bb12e7e1103f4407c341ebc65aeab5b
-  AEPEdge: 6bc7c3f6573fdf0a12fb3ddfd32420112a89c80b
+  AEPAssurance: df04baeace42befb0cc213fd6cdfe51651d11ba6
+  AEPCore: db53082c207c28166ed6aa9ae6262a55e95c78aa
+  AEPEdge: edf73ae8900016940cd7fcb29a89a576a1c6b0ae
   AEPEdgeConsent: d7db1d19eb4c1e2146360ed3c8df315f671b26d5
   AEPEdgeIdentity: 3161ff33434586962946912d6b8e9e8fca1c4d23
-  AEPIdentity: a65c1eba43a06f01b0dab191b27a53a81adada57
+  AEPIdentity: 3c597ef3d734d726f6a48ae10cdecb36fbeb28ca
   AEPRulesEngine: fe5800653a4bee07b1e41e61b4d5551f0dba557b
-  AEPServices: e42e5118128e81c0f797fdfb1dc9c4a714d644b8
-  AEPTestUtils: 20495b368da57904ca2e9f241d1d8b114f9887b5
+  AEPServices: d959143d13fde7e8464c19527df6baacdef765ce
+  AEPTestUtils: ef5a4f6cf9ef61630b7c68b5d205bb885a6f19a2
   SwiftLint: 13280e21cdda6786ad908dc6e416afe5acd1fcb7
 
-PODFILE CHECKSUM: 3d48ef218719be2bc242c009e9147c2ced4e912c
+PODFILE CHECKSUM: 1696457ba4a3362bd146f2959cfa55cb6a71618e
 
 COCOAPODS: 1.14.3

--- a/Tests/UnitTests/IdentityMapTests.swift
+++ b/Tests/UnitTests/IdentityMapTests.swift
@@ -523,8 +523,12 @@ class IdentityMapTests: XCTestCase {
     }
 
     func testFromWithInvalidDataDecode() {
-        let bogusStr = String(bytes: [0xD8, 0x00] as [UInt8], encoding: String.Encoding.utf16BigEndian)!
-        let data = ["foo": bogusStr]
+        let bytes: [UInt8] = [0xD8, 0x00]  // Invalid UTF-16 high surrogate
+        let bytesData = Data(bytes)
+        // Construct invalid String using Obj-C since iOS 18 `String` construction now returns `nil`.
+        // `! as String` validates an invalid String is actually constructed.
+        let invalidStr = NSString(data: bytesData, encoding: String.Encoding.utf16BigEndian.rawValue)! as String
+        let data = ["foo": invalidStr]
         let identityMap = IdentityMap.from(eventData: data)
         XCTAssertNil(identityMap)
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR updates:
1. AEPTestUtils to 5.1.0 which addresses an internal property name change by Core, used by AEPTestUtils
2. A newly breaking test case starting with iOS 18, where the invalid String construction using Swift `String` returns `nil` instead of the invalid String required for the test case - this has been updated to use Obj-C's `NSString` construction instead.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
